### PR TITLE
feat: CLI filters, schedule command, run summary, modified status

### DIFF
--- a/supernote_sync/cli.py
+++ b/supernote_sync/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +38,63 @@ def _load_cfg(ctx: click.Context) -> dict[str, Any]:
         sys.exit(1)
     setup_logging(cfg)
     return cfg
+
+
+def _parse_date_arg(value: str, param_name: str) -> date:
+    """Parse a ``YYYY-MM-DD`` string into a :class:`datetime.date`.
+
+    Args:
+        value: The raw string value from the CLI.
+        param_name: The option name, used in error messages.
+
+    Returns:
+        A :class:`datetime.date` instance.
+
+    Raises:
+        :exc:`click.BadParameter` when the format is invalid.
+    """
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        raise click.BadParameter(
+            f"Expected YYYY-MM-DD, got '{value}'",
+            param_hint=f"'--{param_name}'",
+        )
+
+
+def _mtime_date(path: Path) -> date:
+    """Return the UTC modification date of *path*."""
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).date()
+
+
+def _vault_note_has_tag(note_path: Path, tag: str, notes_dir: Path) -> bool:
+    """Return ``True`` if an existing vault note for *note_path* has *tag*.
+
+    Scans *notes_dir* for Markdown files whose name contains the note stem,
+    then checks their YAML frontmatter for the given tag.
+
+    Args:
+        note_path: The ``.note`` source file.
+        tag: The tag string to look for.
+        notes_dir: Directory in the vault where notes are stored.
+
+    Returns:
+        ``True`` when a matching vault note with the tag is found.
+    """
+    import frontmatter  # noqa: PLC0415
+
+    stem = note_path.stem
+    for md_path in notes_dir.glob(f"*{stem}*.md"):
+        try:
+            post = frontmatter.load(str(md_path))
+            tags: Any = post.get("tags", [])
+            if isinstance(tags, list) and tag in tags:
+                return True
+            if isinstance(tags, str) and tag == tags:
+                return True
+        except Exception:  # noqa: BLE001
+            continue
+    return False
 
 
 @click.group()
@@ -79,21 +137,65 @@ def watch(ctx: click.Context) -> None:
     default=False,
     help="Bypass the dedup cache and overwrite existing notes in the vault.",
 )
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Print what would be processed without writing any files.",
+)
+@click.option(
+    "--since",
+    "since_date",
+    default=None,
+    metavar="DATE",
+    help="Only include files modified on or after DATE (YYYY-MM-DD).",
+)
+@click.option(
+    "--until",
+    "until_date",
+    default=None,
+    metavar="DATE",
+    help="Only include files modified on or before DATE (YYYY-MM-DD).",
+)
+@click.option(
+    "--tag",
+    "filter_tag",
+    default=None,
+    metavar="TAG",
+    help="Only include files whose vault note already has TAG in frontmatter.",
+)
 @click.pass_context
-def once(ctx: click.Context, path: Path | None, force: bool) -> None:
-    """Process .note files once (either a single file, or all in sync_folder).
+def once(
+    ctx: click.Context,
+    path: Path | None,
+    force: bool,
+    dry_run: bool,
+    since_date: str | None,
+    until_date: str | None,
+    filter_tag: str | None,
+) -> None:
+    """Process .note files once (a file, directory, or the configured sync_folder).
 
     PATH  Optional path to a specific .note file or directory.  If omitted,
           all *.note files in the configured sync_folder are processed.
 
+    \b
+    Filtering flags (combinable):
+      --since / --until  narrow by file modification date
+      --tag              narrow by existing vault-note frontmatter tag
+
     Use --force to reprocess files that have already been converted, overwriting
     the existing note in the vault rather than creating a new dated copy.
+
+    Use --dry-run to preview what would run without touching the vault.
     """
     cfg: dict[str, Any] = _load_cfg(ctx)
     from supernote_sync.pipeline import Pipeline  # noqa: PLC0415
 
     pipeline = Pipeline(cfg)
 
+    # ── Resolve note_files ──────────────────────────────────────────────────
     if path is not None:
         target = Path(path)
         if target.is_dir():
@@ -109,33 +211,169 @@ def once(ctx: click.Context, path: Path | None, force: bool) -> None:
         ).expanduser()
         note_files = sorted(sync_folder.glob("*.note"))
 
+    # ── Date filters ─────────────────────────────────────────────────────────
+    since_dt = _parse_date_arg(since_date, "since") if since_date else None
+    until_dt = _parse_date_arg(until_date, "until") if until_date else None
+
+    if since_dt or until_dt:
+        filtered: list[Path] = []
+        for nf in note_files:
+            nd = _mtime_date(nf)
+            if since_dt and nd < since_dt:
+                continue
+            if until_dt and nd > until_dt:
+                continue
+            filtered.append(nf)
+        note_files = filtered
+
+    # ── Tag filter ───────────────────────────────────────────────────────────
+    if filter_tag:
+        obs_cfg = cfg.get("obsidian", {})
+        vault_path = Path(obs_cfg.get("vault_path", "~/Documents/MyVault")).expanduser()
+        notes_dir = vault_path / obs_cfg.get("notes_subfolder", "Supernote")
+        note_files = [
+            nf for nf in note_files
+            if _vault_note_has_tag(nf, filter_tag, notes_dir)
+        ]
+
     if not note_files:
         console.print("[yellow]No .note files found.[/yellow]")
         return
 
-    n = len(note_files)
-    if force:
-        console.print(f"Processing [bold]{n}[/bold] file(s) [yellow](force)[/yellow] …")
-    else:
-        console.print(f"Processing [bold]{n}[/bold] file(s) …")
+    # ── Dry-run: print table and exit ────────────────────────────────────────
+    if dry_run:
+        from rich.table import Table  # noqa: PLC0415
 
-    ok = 0
-    fail = 0
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("File")
+        table.add_column("Size")
+        table.add_column("Modified")
+        table.add_column("Status")
+
+        for nf in note_files:
+            size_kb = nf.stat().st_size // 1024
+            mtime = _mtime_date(nf).isoformat()
+            if pipeline._dedup_enabled and pipeline._dedup is not None:
+                if pipeline._dedup.already_processed(nf) and not force:
+                    status_label = "[dim]already done[/dim]"
+                elif pipeline._dedup.is_modified(nf):
+                    status_label = "[yellow]modified[/yellow]"
+                else:
+                    status_label = "[green]new[/green]"
+            else:
+                status_label = "[green]pending[/green]"
+            table.add_row(nf.name, f"{size_kb} KB", mtime, status_label)
+
+        console.print(table)
+        n = len(note_files)
+        suffix = " [yellow](force)[/yellow]" if force else ""
+        console.print(f"\n[bold]{n}[/bold] file(s) would be processed.{suffix}")
+        return
+
+    # ── Live run ─────────────────────────────────────────────────────────────
+    n = len(note_files)
+    suffix = " [yellow](force)[/yellow]" if force else ""
+    console.print(f"Processing [bold]{n}[/bold] file(s){suffix} …")
+
+    n_new = n_modified = n_skipped = n_failed = 0
+
     for nf in note_files:
-        result = pipeline.process_file(nf, force=force)
-        if result:
-            ok += 1
-            console.print(f"  [green]✓[/green] {nf.name}")
+        # Classify file before processing for the run summary.
+        if pipeline._dedup_enabled and pipeline._dedup is not None:
+            if pipeline._dedup.already_processed(nf):
+                pre_status = "done"
+            elif pipeline._dedup.is_modified(nf):
+                pre_status = "modified"
+            else:
+                pre_status = "new"
         else:
-            fail += 1
+            pre_status = "new"
+
+        result = pipeline.process_file(nf, force=force)
+
+        if result:
+            if pre_status == "modified":
+                n_modified += 1
+            else:
+                n_new += 1
+            console.print(f"  [green]✓[/green] {nf.name}")
+        elif pre_status == "done" and not force:
+            n_skipped += 1
+            console.print(f"  [dim]─[/dim] {nf.name}")
+        else:
+            n_failed += 1
             console.print(f"  [red]✗[/red] {nf.name}")
 
-    console.print(f"\n[bold]Done:[/bold] {ok} succeeded, {fail} failed/skipped.")
+    # Run summary
+    parts = []
+    if n_new:
+        parts.append(f"{n_new} new")
+    if n_modified:
+        parts.append(f"{n_modified} modified")
+    if n_skipped:
+        parts.append(f"{n_skipped} skipped")
+    if n_failed:
+        parts.append(f"[red]{n_failed} failed[/red]")
+    summary = ", ".join(parts) if parts else "nothing to do"
+    console.print(f"\n[bold]Done:[/bold] {summary}.")
 
 
 @main.command()
 @click.option(
-    "--watch/--no-watch", "watch_mode", default=False, help="Poll continuously for new files."
+    "--interval",
+    default=3600,
+    show_default=True,
+    type=int,
+    help="Seconds between each sync run.",
+)
+@click.pass_context
+def schedule(ctx: click.Context, interval: int) -> None:
+    """Process .note files on a recurring schedule using APScheduler.
+
+    Runs immediately on start, then repeats every INTERVAL seconds.
+    """
+    from apscheduler.schedulers.blocking import BlockingScheduler  # noqa: PLC0415
+
+    from supernote_sync.pipeline import Pipeline  # noqa: PLC0415
+
+    cfg: dict[str, Any] = _load_cfg(ctx)
+    pipeline = Pipeline(cfg)
+    sync_folder = Path(
+        cfg.get("supernote", {}).get("sync_folder", "~/supernote-sync")
+    ).expanduser()
+
+    def _run_sync() -> None:
+        note_files = sorted(sync_folder.glob("*.note"))
+        if not note_files:
+            console.print("[yellow]No .note files found in sync folder.[/yellow]")
+            return
+        ok = fail = 0
+        for nf in note_files:
+            if pipeline.process_file(nf):
+                ok += 1
+            else:
+                fail += 1
+        console.print(f"[bold]Run complete:[/bold] {ok} succeeded, {fail} failed/skipped.")
+
+    scheduler: Any = BlockingScheduler()
+    scheduler.add_job(_run_sync, "interval", seconds=interval)
+    console.print(
+        f"[green]Scheduler started[/green] — running every {interval}s …"
+        "  (Ctrl-C to stop)"
+    )
+    _run_sync()  # immediate first run
+    try:
+        scheduler.start()
+    except (KeyboardInterrupt, SystemExit):
+        console.print("\nScheduler stopped.")
+
+
+@main.command()
+@click.option(
+    "--watch/--no-watch",
+    "watch_mode",
+    default=False,
+    help="Poll continuously for new files.",
 )
 @click.pass_context
 def pull(ctx: click.Context, watch_mode: bool) -> None:
@@ -167,11 +405,14 @@ def pull(ctx: click.Context, watch_mode: bool) -> None:
 
     if watch_mode:
         import time  # noqa: PLC0415
+
         interval = wifi_cfg.get("poll_interval_seconds", 60)
         try:
             while True:
                 count = puller.pull()
-                console.print(f"  Pulled {count} new file(s). Next check in {interval}s …")
+                console.print(
+                    f"  Pulled {count} new file(s). Next check in {interval}s …"
+                )
                 time.sleep(interval)
         except KeyboardInterrupt:
             console.print("\nStopping pull loop.")
@@ -201,11 +442,15 @@ def init(ctx: click.Context) -> None:
 
     vault_path = click.prompt("Obsidian vault path", default="~/Documents/MyVault")
     sync_folder = click.prompt("Local sync folder", default="~/supernote-sync")
-    ocr_engine = click.prompt("OCR engine [tesseract/google_vision]", default="tesseract")
-    wifi_host = click.prompt("Supernote IP address (leave blank to skip WiFi)", default="")
+    ocr_engine = click.prompt(
+        "OCR engine [tesseract/google_vision]", default="tesseract"
+    )
+    wifi_host = click.prompt(
+        "Supernote IP address (leave blank to skip WiFi)", default=""
+    )
 
     if example_path.exists():
-        cfg = load_config(example_path)
+        cfg: dict[str, Any] = load_config(example_path)
     else:
         cfg = {}
 
@@ -213,7 +458,7 @@ def init(ctx: click.Context) -> None:
     cfg.setdefault("supernote", {})["sync_folder"] = sync_folder
     cfg.setdefault("obsidian", {})["vault_path"] = vault_path
     cfg.setdefault("ocr", {})["engine"] = ocr_engine
-    wifi_cfg = cfg["supernote"].setdefault("wifi", {})
+    wifi_cfg: dict[str, Any] = cfg["supernote"].setdefault("wifi", {})
     if wifi_host:
         wifi_cfg["host"] = wifi_host
         wifi_cfg["enabled"] = True
@@ -234,7 +479,9 @@ def status(ctx: click.Context) -> None:
 
     cfg = _load_cfg(ctx)
     proc_cfg = cfg.get("processing", {})
-    sync_folder = Path(cfg.get("supernote", {}).get("sync_folder", "~/supernote-sync")).expanduser()
+    sync_folder = Path(
+        cfg.get("supernote", {}).get("sync_folder", "~/supernote-sync")
+    ).expanduser()
 
     if not sync_folder.exists():
         console.print(f"[yellow]Sync folder does not exist:[/yellow] {sync_folder}")
@@ -245,27 +492,42 @@ def status(ctx: click.Context) -> None:
     dedup = None
     if proc_cfg.get("deduplicate", True):
         from supernote_sync.utils.dedup import DedupCache  # noqa: PLC0415
-        state_dir = Path(proc_cfg.get("state_dir", "~/.supernote-sync")).expanduser()
+
+        state_dir = Path(
+            proc_cfg.get("state_dir", "~/.supernote-sync")
+        ).expanduser()
         dedup = DedupCache(state_dir=state_dir)
 
     table = Table(show_header=True, header_style="bold")
     table.add_column("File")
     table.add_column("Size")
+    table.add_column("Modified")
     table.add_column("Status")
 
-    n_processed = 0
-    n_pending = 0
+    n_processed = n_modified_count = n_pending = 0
     for nf in note_files:
         size_kb = nf.stat().st_size // 1024
-        processed = dedup is not None and dedup.already_processed(nf)
-        if processed:
-            n_processed += 1
-            status_str = "[green]processed[/green]"
+        mtime = _mtime_date(nf).isoformat()
+        if dedup is not None:
+            if dedup.already_processed(nf):
+                n_processed += 1
+                status_str = "[green]processed[/green]"
+            elif dedup.is_modified(nf):
+                n_modified_count += 1
+                status_str = "[yellow]modified[/yellow]"
+            else:
+                n_pending += 1
+                status_str = "[blue]new[/blue]"
         else:
             n_pending += 1
             status_str = "[yellow]pending[/yellow]"
-        table.add_row(nf.name, f"{size_kb} KB", status_str)
+        table.add_row(nf.name, f"{size_kb} KB", mtime, status_str)
 
     if note_files:
         console.print(table)
-    console.print(f"\n{n_processed} processed, {n_pending} pending")
+
+    parts = [f"{n_processed} processed"]
+    if n_modified_count:
+        parts.append(f"{n_modified_count} modified")
+    parts.append(f"{n_pending} pending")
+    console.print(f"\n{', '.join(parts)}")

--- a/supernote_sync/utils/dedup.py
+++ b/supernote_sync/utils/dedup.py
@@ -92,6 +92,30 @@ class DedupCache:
             return False
         return self._data[key] == current_hash
 
+    def is_modified(self, path: Path) -> bool:
+        """Return ``True`` if *path* is cached but its content has changed.
+
+        Unlike :meth:`already_processed` (which returns ``False`` for changed
+        files), this method only returns ``True`` when the file was previously
+        processed *and* now has a different MD5 — i.e. it was re-exported.
+        A file that has never been processed returns ``False``.
+
+        Args:
+            path: Path to the ``.note`` file to check.
+
+        Returns:
+            ``True`` when the cached hash differs from the current file hash.
+        """
+        key = str(path)
+        if key not in self._data:
+            return False  # never processed — it's "new", not "modified"
+        try:
+            current_hash = self._md5(path)
+        except OSError as exc:
+            logger.warning("Could not hash %s for modified check: %s", path, exc)
+            return False
+        return self._data[key] != current_hash
+
     def mark_processed(self, path: Path) -> None:
         """Record *path* as successfully processed.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -157,6 +158,258 @@ class TestPullCommand:
         mock_puller.pull.assert_called_once()
 
 
+class TestOnceFilters:
+    """Tests for --since, --until, --tag, and --dry-run on the `once` command."""
+
+    def test_since_filters_out_old_files(
+        self, config_file: Path, tmp_path: Path
+    ) -> None:
+        """--since excludes files modified before the given date."""
+
+        note_dir = tmp_path / "notes"
+        note_dir.mkdir()
+        old_note = note_dir / "old.note"
+        old_note.write_bytes(b"\x00")
+        # Force mtime to 2000-01-01
+        old_ts = 946684800.0  # 2000-01-01 UTC
+        import os
+        os.utime(old_note, (old_ts, old_ts))
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.process_file.return_value = True
+
+        runner = CliRunner()
+        with patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline):
+            result = runner.invoke(
+                main,
+                ["--config", str(config_file), "once", str(note_dir), "--since", "2025-01-01"],
+            )
+
+        assert result.exit_code == 0
+        # old_note should be filtered out → nothing processed
+        assert "No .note files found" in result.output
+
+    def test_until_filters_out_new_files(
+        self, config_file: Path, tmp_path: Path
+    ) -> None:
+        """--until excludes files modified after the given date."""
+        import os
+
+        note_dir = tmp_path / "notes"
+        note_dir.mkdir()
+        future_note = note_dir / "future.note"
+        future_note.write_bytes(b"\x00")
+        # Force mtime to 2099-12-31
+        future_ts = 4102444800.0
+        os.utime(future_note, (future_ts, future_ts))
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.process_file.return_value = True
+
+        runner = CliRunner()
+        with patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline):
+            result = runner.invoke(
+                main,
+                ["--config", str(config_file), "once", str(note_dir), "--until", "2025-01-01"],
+            )
+
+        assert result.exit_code == 0
+        assert "No .note files found" in result.output
+
+    def test_dry_run_prints_table_without_processing(
+        self, config_file: Path, tmp_path: Path
+    ) -> None:
+        """--dry-run prints a preview table and does not call process_file."""
+        note = tmp_path / "test.note"
+        note.write_bytes(b"\x00" * 16)
+
+        mock_pipeline = MagicMock()
+        mock_pipeline._dedup_enabled = False
+        mock_pipeline._dedup = None
+
+        runner = CliRunner()
+        with patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline):
+            result = runner.invoke(
+                main,
+                ["--config", str(config_file), "once", str(note), "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert "test.note" in result.output
+        assert "would be processed" in result.output
+        mock_pipeline.process_file.assert_not_called()
+
+    def test_dry_run_with_force_shows_force_suffix(
+        self, config_file: Path, tmp_path: Path
+    ) -> None:
+        """--dry-run --force shows the (force) label."""
+        note = tmp_path / "test.note"
+        note.write_bytes(b"\x00" * 16)
+
+        mock_pipeline = MagicMock()
+        mock_pipeline._dedup_enabled = False
+        mock_pipeline._dedup = None
+
+        runner = CliRunner()
+        with patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline):
+            result = runner.invoke(
+                main,
+                ["--config", str(config_file), "once", str(note), "--dry-run", "--force"],
+            )
+
+        assert result.exit_code == 0
+        assert "force" in result.output.lower()
+
+    def test_since_bad_date_exits_nonzero(self, config_file: Path) -> None:
+        """--since with a bad date string exits with a non-zero code."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["--config", str(config_file), "once", "--since", "not-a-date"]
+        )
+        assert result.exit_code != 0
+
+    def test_until_bad_date_exits_nonzero(self, config_file: Path) -> None:
+        """--until with a bad date string exits with a non-zero code."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["--config", str(config_file), "once", "--until", "31/12/2025"]
+        )
+        assert result.exit_code != 0
+
+
+class TestRunSummary:
+    """Tests for the per-run summary line in `once`."""
+
+    def test_summary_shows_new_count(self, config_file: Path, tmp_path: Path) -> None:
+        """Run summary includes 'N new' when new files are processed."""
+        note = tmp_path / "fresh.note"
+        note.write_bytes(b"\x00" * 16)
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.process_file.return_value = True
+        mock_pipeline._dedup_enabled = True
+        mock_dedup = MagicMock()
+        mock_dedup.already_processed.return_value = False
+        mock_dedup.is_modified.return_value = False
+        mock_pipeline._dedup = mock_dedup
+
+        runner = CliRunner()
+        with patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline):
+            result = runner.invoke(
+                main, ["--config", str(config_file), "once", str(note)]
+            )
+
+        assert result.exit_code == 0
+        assert "1 new" in result.output
+
+    def test_summary_shows_skipped_count(
+        self, config_file: Path, tmp_path: Path
+    ) -> None:
+        """Run summary includes 'N skipped' when files are already processed."""
+        note = tmp_path / "done.note"
+        note.write_bytes(b"\x00" * 16)
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.process_file.return_value = False
+        mock_pipeline._dedup_enabled = True
+        mock_dedup = MagicMock()
+        mock_dedup.already_processed.return_value = True
+        mock_dedup.is_modified.return_value = False
+        mock_pipeline._dedup = mock_dedup
+
+        runner = CliRunner()
+        with patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline):
+            result = runner.invoke(
+                main, ["--config", str(config_file), "once", str(note)]
+            )
+
+        assert result.exit_code == 0
+        assert "1 skipped" in result.output
+
+    def test_summary_shows_modified_count(
+        self, config_file: Path, tmp_path: Path
+    ) -> None:
+        """Run summary includes 'N modified' when re-exported files are processed."""
+        note = tmp_path / "changed.note"
+        note.write_bytes(b"\x00" * 16)
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.process_file.return_value = True
+        mock_pipeline._dedup_enabled = True
+        mock_dedup = MagicMock()
+        mock_dedup.already_processed.return_value = False
+        mock_dedup.is_modified.return_value = True
+        mock_pipeline._dedup = mock_dedup
+
+        runner = CliRunner()
+        with patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline):
+            result = runner.invoke(
+                main, ["--config", str(config_file), "once", str(note)]
+            )
+
+        assert result.exit_code == 0
+        assert "1 modified" in result.output
+
+
+class TestScheduleCommand:
+    """Tests for the `schedule` command."""
+
+    def test_schedule_calls_process_file(
+        self, config_file: Path, tmp_path: Path
+    ) -> None:
+        """schedule runs process_file for each .note in the sync folder."""
+        import yaml
+
+        cfg = yaml.safe_load(config_file.read_text())
+        sync = Path(cfg["supernote"]["sync_folder"])
+        sync.mkdir(parents=True, exist_ok=True)
+        (sync / "a.note").write_bytes(b"\x00")
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.process_file.return_value = True
+
+        # APScheduler's BlockingScheduler.start() blocks; patch it to return immediately
+        mock_scheduler = MagicMock()
+        mock_scheduler.start.side_effect = KeyboardInterrupt
+
+        runner = CliRunner()
+        with (
+            patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline),
+            patch(
+                "apscheduler.schedulers.blocking.BlockingScheduler",
+                return_value=mock_scheduler,
+            ),
+        ):
+            result = runner.invoke(
+                main, ["--config", str(config_file), "schedule", "--interval", "60"]
+            )
+
+        assert result.exit_code == 0
+        # process_file called at least once (the immediate first run)
+        mock_pipeline.process_file.assert_called()
+
+    def test_schedule_no_notes_prints_warning(self, config_file: Path) -> None:
+        """schedule prints a warning when the sync folder is empty."""
+        mock_pipeline = MagicMock()
+        mock_scheduler = MagicMock()
+        mock_scheduler.start.side_effect = KeyboardInterrupt
+
+        runner = CliRunner()
+        with (
+            patch("supernote_sync.pipeline.Pipeline", return_value=mock_pipeline),
+            patch(
+                "apscheduler.schedulers.blocking.BlockingScheduler",
+                return_value=mock_scheduler,
+            ),
+        ):
+            result = runner.invoke(
+                main, ["--config", str(config_file), "schedule"]
+            )
+
+        assert result.exit_code == 0
+        assert "No .note files found" in result.output
+
+
 def test_status_empty_sync_folder(tmp_path, mocker):
     """status command with empty sync folder prints 0 processed, 0 pending."""
     from click.testing import CliRunner
@@ -182,3 +435,45 @@ def test_status_empty_sync_folder(tmp_path, mocker):
 
     result = runner.invoke(main, ["--config", str(config_file), "status"])
     assert "0 processed, 0 pending" in result.output
+
+
+def test_status_shows_modified_files(tmp_path: Path, mocker: Any) -> None:
+    """status shows 'modified' for files in the dedup cache with changed content."""
+    from click.testing import CliRunner
+
+    from supernote_sync.cli import main
+    from supernote_sync.utils.dedup import DedupCache
+
+    sync_dir = tmp_path / "sync"
+    sync_dir.mkdir()
+    note = sync_dir / "changed.note"
+    note.write_bytes(b"original content")
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    # Mark as processed, then change the file content
+    cache = DedupCache(state_dir)
+    cache.mark_processed(note)
+    note.write_bytes(b"re-exported different content")
+
+    cfg = {
+        "supernote": {"sync_folder": str(sync_dir), "wifi": {"enabled": False}},
+        "obsidian": {"vault_path": str(tmp_path / "vault")},
+        "ocr": {"engine": "tesseract", "low_confidence_threshold": 0.7},
+        "processing": {
+            "deduplicate": True, "state_dir": str(state_dir), "render_dpi": 200
+        },
+        "logging": {
+            "level": "WARNING", "log_dir": str(tmp_path / "logs"), "max_log_files": 3
+        },
+    }
+    mocker.patch("supernote_sync.cli.load_config", return_value=cfg)
+    mocker.patch("supernote_sync.cli.setup_logging")
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("dummy: true")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(config_file), "status"])
+    assert "modified" in result.output

--- a/tests/test_ingestion/test_dedup.py
+++ b/tests/test_ingestion/test_dedup.py
@@ -66,3 +66,40 @@ class TestDedupCache:
 
         assert cache.already_processed(file_a) is True
         assert cache.already_processed(file_b) is False
+
+    # ── is_modified ──────────────────────────────────────────────────────────
+
+    def test_is_modified_false_for_new_file(
+        self, state_dir: Path, note_file: Path
+    ) -> None:
+        """is_modified returns False for a file never processed before."""
+        cache = DedupCache(state_dir)
+        assert cache.is_modified(note_file) is False
+
+    def test_is_modified_false_when_unchanged(
+        self, state_dir: Path, note_file: Path
+    ) -> None:
+        """is_modified returns False when the content has not changed."""
+        cache = DedupCache(state_dir)
+        cache.mark_processed(note_file)
+        assert cache.is_modified(note_file) is False
+
+    def test_is_modified_true_after_content_change(
+        self, state_dir: Path, note_file: Path
+    ) -> None:
+        """is_modified returns True after a file's content changes."""
+        cache = DedupCache(state_dir)
+        cache.mark_processed(note_file)
+        note_file.write_bytes(b"re-exported with different bytes")
+        assert cache.is_modified(note_file) is True
+
+    def test_is_modified_and_already_processed_are_mutually_exclusive(
+        self, state_dir: Path, note_file: Path
+    ) -> None:
+        """A file cannot be both already_processed and is_modified."""
+        cache = DedupCache(state_dir)
+        cache.mark_processed(note_file)
+        note_file.write_bytes(b"changed content")
+        # After change: is_modified=True, already_processed=False
+        assert cache.is_modified(note_file) is True
+        assert cache.already_processed(note_file) is False


### PR DESCRIPTION
## Summary

Closes issues #1 and #3.

**Issue #3 — CLI: collections/filters + dry-run diff**
- `once --dry-run` — previews what would be processed as a Rich table without touching the vault
- `once --since DATE` / `--until DATE` — filters `.note` files by modification date (YYYY-MM-DD)
- `once --tag TAG` — filters to files whose existing vault note already has the tag in frontmatter

**Issue #1 — Batch/delta export + scheduling**
- `schedule --interval N` — runs the full sync on a recurring APScheduler timer; immediate first run on startup
- `once` run summary — prints `"1 new, 2 modified, 5 skipped"` after each batch
- `status` enhanced — shows `modified` (yellow) for files whose content changed since last processing
- `DedupCache.is_modified()` — new method: `True` when a file is cached but its MD5 has changed

## Test plan
- [x] `ruff check` passes
- [x] `mypy supernote_sync` passes
- [x] 99 tests passing, 81% coverage
- [x] `--since` / `--until` filter by mtime verified with explicit timestamp patching
- [x] `--dry-run` verifies no `process_file` calls made
- [x] run summary counts (new / modified / skipped) verified per test case
- [x] `schedule` command tested with mocked APScheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)